### PR TITLE
feat: add selectable minimal portfolio layoutFeature/minimal layout

### DIFF
--- a/SETUP_DB.sql
+++ b/SETUP_DB.sql
@@ -21,6 +21,7 @@ create table profiles (
   cta_text text,
   cta_link text,
   theme text default 'dark',
+  layout text default 'classic', -- Public profile layout: 'classic' | 'minimal'
   beams_enabled boolean default true,
   is_donor boolean default false,
   cv_url text,

--- a/components/dashboard/LayoutHiddenWrapper.tsx
+++ b/components/dashboard/LayoutHiddenWrapper.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { FiEyeOff } from "react-icons/fi";
+
+/**
+ * Wraps a dashboard card that is NOT rendered on the public "minimal" layout.
+ * When `hidden` is true it dims the card and shows a small badge so the user
+ * understands the card's content won't appear on their profile. The card stays
+ * editable (they may switch back to the classic layout).
+ */
+const LayoutHiddenWrapper: React.FC<{ hidden: boolean; children: React.ReactNode }> = ({
+    hidden,
+    children,
+}) => {
+    if (!hidden) return <>{children}</>;
+
+    return (
+        <div className="relative">
+            <div className="absolute top-3 left-1/2 -translate-x-1/2 z-30 flex items-center gap-1.5 px-3 py-1 rounded-full bg-black/75 border border-white/10 text-[10px] font-bold uppercase tracking-widest text-white/60 pointer-events-none backdrop-blur-md">
+                <FiEyeOff size={11} /> Hidden on Minimal
+            </div>
+            <div className="opacity-40 transition-opacity">{children}</div>
+        </div>
+    );
+};
+
+export default LayoutHiddenWrapper;

--- a/components/dashboard/LayoutSettings.tsx
+++ b/components/dashboard/LayoutSettings.tsx
@@ -1,0 +1,135 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { FiCheck, FiLoader } from 'react-icons/fi';
+import { useAuth } from '../../lib/AuthContext';
+import { toast } from 'react-toastify';
+
+const layouts = [
+    {
+        id: 'classic',
+        name: 'Classic',
+        description: 'Rich cards, GitHub graph, tech stack & CTA.',
+    },
+    {
+        id: 'minimal',
+        name: 'Minimal',
+        description: 'Single-column, serif type, quiet and text-forward.',
+    },
+];
+
+// Small wireframe previews so the difference is legible at a glance.
+const ClassicPreview = () => (
+    <div className="w-full h-full p-3 flex flex-col gap-2">
+        <div className="h-6 rounded-md bg-white/10" />
+        <div className="grid grid-cols-3 gap-2 flex-1">
+            <div className="rounded-md bg-white/10" />
+            <div className="rounded-md bg-white/10" />
+            <div className="rounded-md bg-white/10" />
+        </div>
+    </div>
+);
+
+const MinimalPreview = () => (
+    <div className="w-full h-full p-3 flex flex-col items-center gap-2">
+        <div className="w-5 h-5 rounded-full bg-white/15 mt-1" />
+        <div className="h-3 w-24 rounded bg-white/15" />
+        <div className="h-1.5 w-16 rounded bg-white/10" />
+        <div className="mt-1 h-1.5 w-28 rounded bg-white/10" />
+        <div className="h-1.5 w-24 rounded bg-white/10" />
+    </div>
+);
+
+const LayoutSettings: React.FC = () => {
+    const { user, supabase } = useAuth();
+    const [selected, setSelected] = useState('classic');
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        const fetchLayout = async () => {
+            if (!user) return;
+            const { data, error } = await supabase
+                .from('profiles')
+                .select('layout')
+                .eq('id', user.id)
+                .single();
+            if (data && !error && data.layout) setSelected(data.layout);
+        };
+        fetchLayout();
+    }, [user, supabase]);
+
+    const handleSelect = async (id: string) => {
+        if (!user || id === selected) return;
+        const previous = selected;
+        setSelected(id);
+        setSaving(true);
+        try {
+            const { error } = await supabase
+                .from('profiles')
+                .update({ layout: id, updated_at: new Date().toISOString() })
+                .eq('id', user.id);
+            if (error) throw error;
+        } catch (err) {
+            console.error('Failed to save layout', err);
+            toast.error('Failed to save layout');
+            setSelected(previous);
+        } finally {
+            setTimeout(() => setSaving(false), 800);
+        }
+    };
+
+    return (
+        <section className="mb-12">
+            <div className="mb-6 flex items-end justify-between">
+                <div className="text-center md:text-left">
+                    <h3 className="text-2xl font-black text-white tracking-tighter">Layout</h3>
+                    <p className="text-white/40 text-sm font-medium uppercase tracking-widest mt-1">
+                        How your profile is structured
+                    </p>
+                </div>
+                {saving && (
+                    <div className="flex items-center gap-2 text-yellow-500 font-bold text-xs uppercase tracking-widest animate-pulse">
+                        <FiLoader className="animate-spin" />
+                        <span>Syncing...</span>
+                    </div>
+                )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {layouts.map((layout) => (
+                    <button
+                        key={layout.id}
+                        onClick={() => handleSelect(layout.id)}
+                        className="group relative flex flex-col text-left cursor-pointer"
+                    >
+                        <div
+                            className={`w-full h-40 rounded-[2rem] mb-4 relative overflow-hidden bg-[#0c0b09] transition-all duration-300 border-2 ${selected === layout.id
+                                ? 'border-blue-500'
+                                : 'border-transparent group-hover:border-white/10'
+                                }`}
+                        >
+                            {layout.id === 'classic' ? <ClassicPreview /> : <MinimalPreview />}
+                            {selected === layout.id && (
+                                <motion.div
+                                    initial={{ opacity: 0, scale: 0.5 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    className="absolute top-4 right-4 w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center text-white"
+                                >
+                                    <FiCheck />
+                                </motion.div>
+                            )}
+                        </div>
+                        <p
+                            className={`font-bold tracking-tight transition-colors ${selected === layout.id ? 'text-white' : 'text-white/40 group-hover:text-white/70'
+                                }`}
+                        >
+                            {layout.name}
+                        </p>
+                        <p className="text-white/30 text-xs mt-0.5">{layout.description}</p>
+                    </button>
+                ))}
+            </div>
+        </section>
+    );
+};
+
+export default LayoutSettings;

--- a/components/dashboard/ThemeSettings.tsx
+++ b/components/dashboard/ThemeSettings.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../lib/AuthContext';
 import { toast } from 'react-toastify';
 
 const themes = [
+    { id: 'sand', name: 'Warm Paper', type: 'solid', preview: 'bg-[#0c0b09] border border-[#f5f2eb]/10' },
     { id: 'onyx', name: 'Onyx Dark', type: 'solid', preview: 'bg-black border border-white/10' },
     { id: 'ghost', name: 'Ghost', type: 'solid', preview: 'bg-zinc-950 border border-zinc-900' },
     { id: 'midnight', name: 'Midnight Royal', type: 'solid', preview: 'bg-[#020617] border border-blue-900/30' },

--- a/components/profile/MinimalProfile.tsx
+++ b/components/profile/MinimalProfile.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import Image from "next/image";
+import { motion } from "framer-motion";
+import { FaUser } from "react-icons/fa";
+import { FiArrowUpRight } from "react-icons/fi";
+import { SOCIAL_BASE_URLS } from "../../lib/constants";
+import { ensureAbsoluteUrl, formatSocialHref } from "../../lib/utils";
+
+type SocialLink = { name: string; href: string };
+type TechItem = { name: string };
+type Project = {
+    id: string;
+    title: string;
+    description: string;
+    url: string;
+    image_url: string;
+    tech_tags: string[];
+};
+
+type MinimalUser = {
+    full_name: string;
+    profession?: string;
+    bio?: string;
+    avatar_url?: string;
+    social_links?: SocialLink[];
+    tech_stack?: TechItem[];
+    is_donor?: boolean;
+    cv_url?: string;
+    full_name_slug?: string;
+};
+
+type Props = {
+    user: MinimalUser;
+    projects: Project[];
+    recordClick: (type: string, url: string) => void;
+    onShare: () => void;
+};
+
+const getDomain = (url: string): string => {
+    try {
+        return new URL(ensureAbsoluteUrl(url)).hostname.replace(/^www\./, "");
+    } catch {
+        return "";
+    }
+};
+
+const MinimalProfile: React.FC<Props> = ({ user, projects, recordClick, onShare }) => {
+    const socialLinks = (user.social_links || []).filter((s) => s.href);
+    const tech = user.tech_stack || [];
+    const hasTech = tech.length > 0;
+    const hasProjects = projects && projects.length > 0;
+
+    return (
+        <main className="font-dm min-h-screen px-6 py-16 md:py-24 selection:bg-[var(--theme-text)] selection:text-[var(--theme-card-bg)]">
+            <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.5, ease: "easeOut" }}
+                className="mx-auto w-full max-w-[620px]"
+            >
+                {/* Header */}
+                <header className="mb-16">
+                    <div
+                        className={`w-14 h-14 rounded-full overflow-hidden relative flex items-center justify-center bg-[var(--theme-card-bg)] border ${user.is_donor
+                            ? "border-yellow-500/50 ring-2 ring-yellow-500/10"
+                            : "border-[var(--theme-border)]"
+                            }`}
+                    >
+                        {user.avatar_url ? (
+                            <Image src={user.avatar_url} alt={user.full_name} fill className="object-cover" />
+                        ) : (
+                            <FaUser className="text-[var(--theme-text-secondary)] text-xl" />
+                        )}
+                    </div>
+
+                    <h1 className="font-serif-display text-[2.6rem] md:text-[3.25rem] leading-[1.05] tracking-[-0.02em] text-[var(--theme-text)] mt-6">
+                        {user.full_name}
+                    </h1>
+
+                    {user.profession && (
+                        <p className="mt-3 text-[11px] uppercase tracking-[0.22em] text-[var(--theme-text-secondary)]">
+                            {user.profession}
+                        </p>
+                    )}
+
+                    {user.bio && (
+                        <p className="mt-6 text-[15px] leading-relaxed text-[var(--theme-text-secondary)]">
+                            {user.bio}
+                        </p>
+                    )}
+
+                    {(socialLinks.length > 0 || user.cv_url) && (
+                        <div className="mt-6 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-[13px] text-[var(--theme-text-secondary)]">
+                            {socialLinks.map((social, i) => (
+                                <React.Fragment key={social.name + i}>
+                                    {i > 0 && <span className="opacity-40 select-none">·</span>}
+                                    <a
+                                        href={formatSocialHref(social.name, social.href, SOCIAL_BASE_URLS)}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        onClick={() => recordClick("social", social.name)}
+                                        className="underline-offset-4 hover:underline hover:text-[var(--theme-text)] transition-colors"
+                                    >
+                                        {social.name}
+                                    </a>
+                                </React.Fragment>
+                            ))}
+                            {user.cv_url && (
+                                <>
+                                    {socialLinks.length > 0 && <span className="opacity-40 select-none">·</span>}
+                                    <a
+                                        href={`${user.cv_url}?download=`}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        onClick={() => recordClick("cv", user.cv_url!)}
+                                        className="underline-offset-4 hover:underline hover:text-[var(--theme-text)] transition-colors"
+                                    >
+                                        Résumé
+                                    </a>
+                                </>
+                            )}
+                        </div>
+                    )}
+                </header>
+
+                {/* Tech stack */}
+                {hasTech && (
+                    <section className="mb-12">
+                        <h2 className="font-serif-display text-[1.75rem] leading-none text-[var(--theme-text)] pb-4 mb-5 border-b border-[var(--theme-border)]">
+                            Stack
+                        </h2>
+                        <p className="text-[14px] leading-relaxed text-[var(--theme-text-secondary)]">
+                            {tech.map((t, i) => (
+                                <React.Fragment key={t.name + i}>
+                                    {i > 0 && <span className="opacity-40 select-none"> · </span>}
+                                    {t.name}
+                                </React.Fragment>
+                            ))}
+                        </p>
+                    </section>
+                )}
+
+                {/* Projects */}
+                {hasProjects && (
+                    <section className="mt-6 mb-16">
+                        <h2 className="font-serif-display text-[1.75rem] leading-none text-[var(--theme-text)] pb-5 mb-2 border-b border-[var(--theme-border)]">
+                            Projects
+                        </h2>
+                        <ul>
+                            {projects.map((project) => {
+                                const domain = getDomain(project.url);
+                                const RowTag = project.url ? "a" : "div";
+                                return (
+                                    <li key={project.id} className="py-7 border-b border-[var(--theme-border)] last:border-b-0">
+                                        <RowTag
+                                            {...(project.url
+                                                ? {
+                                                    href: ensureAbsoluteUrl(project.url),
+                                                    target: "_blank",
+                                                    rel: "noreferrer",
+                                                    onClick: () => recordClick("project", project.title),
+                                                }
+                                                : {})}
+                                            className="group block"
+                                        >
+                                            <h3 className="font-serif-display text-[17px] leading-snug text-[var(--theme-text)] transition-opacity group-hover:opacity-70">
+                                                {project.title}
+                                            </h3>
+                                            {domain && (
+                                                <span className="mt-1 inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.14em] text-[var(--theme-text-secondary)] opacity-70">
+                                                    {domain}
+                                                    <FiArrowUpRight className="transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" />
+                                                </span>
+                                            )}
+                                            {project.description && (
+                                                <p className="mt-2 text-[15px] leading-relaxed text-[var(--theme-text-secondary)]">
+                                                    {project.description}
+                                                </p>
+                                            )}
+                                        </RowTag>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </section>
+                )}
+
+                {/* Footer */}
+                <footer className="pt-8 border-t border-[var(--theme-border)] flex items-center justify-between text-[12px] text-[var(--theme-text-secondary)]">
+                    <a
+                        href="https://devbio.co"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-[var(--theme-text)] transition-colors"
+                    >
+                        Built with DevBio.co
+                    </a>
+                    <button onClick={onShare} className="hover:text-[var(--theme-text)] transition-colors cursor-pointer">
+                        Share
+                    </button>
+                </footer>
+            </motion.div>
+        </main>
+    );
+};
+
+export default MinimalProfile;

--- a/lib/constants.tsx
+++ b/lib/constants.tsx
@@ -53,6 +53,17 @@ export type ThemeStyle = {
 };
 
 export const THEME_CONFIG: Record<string, ThemeStyle> = {
+    // Warm paper-dark, default for the Minimal layout
+    'sand': {
+        bg: 'bg-[#0c0b09]',
+        card: 'rgba(245, 242, 235, 0.03)',
+        border: 'rgba(245, 242, 235, 0.10)',
+        accent: '#f5f2eb',
+        accentText: '#0c0b09',
+        text: '#f5f2eb',
+        textSecondary: '#9a958c',
+        heroGradient: 'linear-gradient(to top, #0c0b09 10%, rgba(12,11,9,0.8) 50%, rgba(245,242,235,0.05) 100%)'
+    },
     // Solid Colors
     'onyx': {
         bg: 'bg-[#000000]',

--- a/pages/[profile].tsx
+++ b/pages/[profile].tsx
@@ -7,6 +7,7 @@ import { FaXTwitter } from "react-icons/fa6";
 import { motion } from "framer-motion";
 import { supabase } from "../lib/supabaseClient";
 import GitHubCard from "../components/GitHubCard";
+import MinimalProfile from "../components/profile/MinimalProfile";
 import PublicShareModal from "../components/PublicShareModal";
 import Link from "next/link";
 import { useState, useEffect, useRef } from "react";
@@ -57,6 +58,7 @@ type UserProfile = {
   beams_enabled?: boolean;
   is_donor?: boolean;
   cv_url?: string;
+  layout?: string;
 };
 
 type Props = {
@@ -103,9 +105,14 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     .eq('is_hidden', false)
     .order('sort_order', { ascending: true });
 
+  // Allow previewing a layout without saving it: /username?layout=minimal
+  const layoutQuery = context.query.layout;
+  const layoutOverride =
+    layoutQuery === 'minimal' || layoutQuery === 'classic' ? layoutQuery : null;
+
   return {
     props: {
-      user: profile,
+      user: layoutOverride ? { ...profile, layout: layoutOverride } : profile,
       projects: projects || [],
     },
   };
@@ -184,7 +191,19 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
   const leftColClass = !hasAboutMe ? "md:col-span-12" : "md:col-span-8";
   const rightColClass = !hasLeftColumn ? "md:col-span-12" : "md:col-span-4";
 
-  const themeConfig = THEME_CONFIG[user.theme || 'onyx'] || THEME_CONFIG['onyx'];
+  const isMinimal = user.layout === 'minimal';
+  // Minimal defaults to the warm "sand" palette. The default-ish dark themes
+  // (onyx / dark / unset) fall through to sand so minimal reads warm out of the
+  // box; a distinctive chosen theme (forest, midnight, matrix, ...) still wins.
+  let resolvedThemeKey: string;
+  if (isMinimal) {
+    const isDefaultish =
+      !user.theme || user.theme === 'dark' || user.theme === 'onyx' || !THEME_CONFIG[user.theme];
+    resolvedThemeKey = isDefaultish ? 'sand' : user.theme!;
+  } else {
+    resolvedThemeKey = user.theme && THEME_CONFIG[user.theme] ? user.theme : 'onyx';
+  }
+  const themeConfig = THEME_CONFIG[resolvedThemeKey] || THEME_CONFIG['onyx'];
   const bgConfig = themeConfig.bg;
   const isImageBg = bgConfig.startsWith('http');
 
@@ -234,6 +253,15 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
         </div>
       )}
 
+      {isMinimal ? (
+        <MinimalProfile
+          user={user}
+          projects={projects}
+          recordClick={recordClick}
+          onShare={() => setShareModalOpen(true)}
+        />
+      ) : (
+      <>
       {/* Floating Share Button - Premium Glassmorphism Neon Version */}
       <motion.div
         animate={{
@@ -602,6 +630,8 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
           </a>
         </motion.footer>
       </main>
+      </>
+      )}
 
       <AnimatePresence>
         {shareModalOpen && (

--- a/pages/dashboard/index.tsx
+++ b/pages/dashboard/index.tsx
@@ -13,6 +13,7 @@ import CTAModal from "../../components/dashboard/edit/CTAModal";
 import Portal from "../../components/Portal";
 import DashboardHero from "../../components/dashboard/DashboardHero";
 import GitHubDNACard from "../../components/dashboard/GitHubDNACard";
+import LayoutHiddenWrapper from "../../components/dashboard/LayoutHiddenWrapper";
 import CVCard from "../../components/dashboard/cv/CVCard";
 import ProjectGrid from "../../components/dashboard/ProjectGrid";
 import CVDeleteModal from "../../components/dashboard/cv/CVDeleteModal";
@@ -73,6 +74,7 @@ const DashboardPage: React.FC = () => {
   const [ctaText, setCtaText] = useState("");
   const [ctaLink, setCtaLink] = useState("");
   const [theme, setTheme] = useState('onyx');
+  const [layout, setLayout] = useState('classic');
   const [isDonor, setIsDonor] = useState(false);
   const [cvUrl, setCvUrl] = useState("");
 
@@ -181,6 +183,7 @@ const DashboardPage: React.FC = () => {
           setCtaText(profile.cta_text || "");
           setCtaLink(profile.cta_link || "");
           setTheme(profile.theme || 'onyx');
+          setLayout(profile.layout || 'classic');
           setIsDonor(profile.is_donor || false);
           setCvUrl(profile.cv_url || "");
 
@@ -532,12 +535,14 @@ const DashboardPage: React.FC = () => {
 
           <div className="grid grid-cols-1 md:grid-cols-12 gap-8 mb-20">
             <motion.div initial={{ opacity: 0, y: 20 }} whileInView={{ opacity: 1, y: 0 }} viewport={{ once: true }} className="md:col-span-8 flex flex-col gap-8">
-              <GitHubDNACard
-                githubUsername={githubUsername}
-                githubGraphTitle={githubGraphTitle}
-                onTitleSave={(val) => { setGithubGraphTitle(val); autoSaveProfile({ github_graph_title: val }); }}
-                onSettingsClick={() => setGithubModalOpen(true)}
-              />
+              <LayoutHiddenWrapper hidden={layout === 'minimal'}>
+                <GitHubDNACard
+                  githubUsername={githubUsername}
+                  githubGraphTitle={githubGraphTitle}
+                  onTitleSave={(val) => { setGithubGraphTitle(val); autoSaveProfile({ github_graph_title: val }); }}
+                  onSettingsClick={() => setGithubModalOpen(true)}
+                />
+              </LayoutHiddenWrapper>
 
               <TechStackCard
                 techStack={techStack}
@@ -546,10 +551,12 @@ const DashboardPage: React.FC = () => {
             </motion.div>
 
             <motion.div initial={{ opacity: 0, x: 20 }} whileInView={{ opacity: 1, x: 0 }} viewport={{ once: true }} className="md:col-span-4 space-y-8">
-              <AboutMeCard
-                aboutMe={aboutMe}
-                onSave={(val) => { setAboutMe(val); autoSaveProfile({ about_me: val }); }}
-              />
+              <LayoutHiddenWrapper hidden={layout === 'minimal'}>
+                <AboutMeCard
+                  aboutMe={aboutMe}
+                  onSave={(val) => { setAboutMe(val); autoSaveProfile({ about_me: val }); }}
+                />
+              </LayoutHiddenWrapper>
 
               <StatusCard
                 isAvailable={isAvailable}
@@ -575,11 +582,13 @@ const DashboardPage: React.FC = () => {
             onReorder={handleReorder}
           />
 
-          <CTACard
-            ctaTitle={ctaTitle}
-            ctaDescription={ctaDescription}
-            onClick={() => setCtaModalOpen(true)}
-          />
+          <LayoutHiddenWrapper hidden={layout === 'minimal'}>
+            <CTACard
+              ctaTitle={ctaTitle}
+              ctaDescription={ctaDescription}
+              onClick={() => setCtaModalOpen(true)}
+            />
+          </LayoutHiddenWrapper>
         </div>
       </div>
 

--- a/pages/dashboard/themes.tsx
+++ b/pages/dashboard/themes.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import DashboardLayout from '../../components/dashboard/DashboardLayout';
 import ThemeSettings from '../../components/dashboard/ThemeSettings';
+import LayoutSettings from '../../components/dashboard/LayoutSettings';
 
 const ThemesPage: React.FC = () => {
     return (
@@ -13,6 +14,7 @@ const ThemesPage: React.FC = () => {
                     </h1>
                     <p className="text-white/40 text-base font-light italic">Customize your profile&apos;s appearance and design.</p>
                 </div>
+                <LayoutSettings />
                 <ThemeSettings />
             </div>
 
@@ -29,6 +31,7 @@ const ThemesPage: React.FC = () => {
 
                     {/* Scrollable Content */}
                     <div className="flex-1 overflow-y-auto px-10 pb-10 custom-scrollbar">
+                        <LayoutSettings />
                         <ThemeSettings />
                     </div>
                 </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&family=Newsreader:ital,wght@0,300;0,400;0,500;1,400&family=DM+Sans:wght@400;500;600&display=swap');
 @import "tailwindcss";
 
 @theme inline {
@@ -91,5 +91,14 @@ body {
   .hide-scrollbar {
     -ms-overflow-style: none;
     scrollbar-width: none;
+  }
+
+  /* Minimal layout typography */
+  .font-serif-display {
+    font-family: 'Newsreader', Georgia, ui-serif, serif;
+  }
+
+  .font-dm {
+    font-family: 'DM Sans', ui-sans-serif, system-ui, sans-serif;
   }
 }


### PR DESCRIPTION
## Overview
Adds a new **Minimal** public-profile layout (inspired by akinkunmi.dev) that users can select alongside the existing Classic layout. It's a single-column, text-forward design with serif headings and a warm paper-dark palette.

## What's included

**New minimal layout**
- Single ~620px column, **Newsreader** serif headings + **DM Sans** body, warm `#0c0b09` / cream `#f5f2eb` palette (new **Warm Paper** / `sand` theme).
- Keeps a small avatar (with donor gold accent) and the tech stack (as inline text).
- Projects render as name / `DOMAIN ↗` / description, with dividers under the Stack heading, the Projects heading, and each project (except the last).
- Drops the GitHub graph and CTA to stay minimal.
- Defaults to the Sand palette, but a distinctive chosen theme still wins — so colors remain changeable.
**Dashboard**
- New **Layout** control (Classic / Minimal) on the Themes page, backed by a new `profiles.layout` column (default `classic`).
- Cards the minimal layout doesn't use (GitHub DNA, About Me, CTA) are dimmed with a **"Hidden on Minimal"** badge so it's clear their content won't appear publicly. Cards stay editable.

## Files
- `components/profile/MinimalProfile.tsx` — the minimal layout
- `components/dashboard/LayoutSettings.tsx` — Classic/Minimal toggle
- `components/dashboard/LayoutHiddenWrapper.tsx` — dims + badges hidden cards
- `pages/[profile].tsx` — layout branching, Sand default, `?layout=` preview
- `pages/dashboard/index.tsx`, `pages/dashboard/themes.tsx` — dashboard wiring
- `lib/constants.tsx`, `components/dashboard/ThemeSettings.tsx` — Sand theme
- `styles/globals.css` — Newsreader + DM Sans fonts
- `SETUP_DB.sql` — schema
