### PR TITLE
Feat/minimal loading screen

### DIFF
--- a/SETUP_DB.sql
+++ b/SETUP_DB.sql
@@ -22,11 +22,15 @@ create table profiles (
   cta_link text,
   theme text default 'dark',
   layout text default 'classic', -- Public profile layout: 'classic' | 'minimal'
+  loader_delay_ms integer default 2800, -- Minimal-layout boot screen duration; 0 disables it
   beams_enabled boolean default true,
   is_donor boolean default false,
   cv_url text,
-  
-  constraint username_length check (char_length(username) >= 3)
+
+  constraint username_length check (char_length(username) >= 3),
+  -- 0 = off, otherwise keep it inside a sane range so a profile can't be
+  -- bricked behind a 10-minute loading screen.
+  constraint loader_delay_range check (loader_delay_ms >= 0 and loader_delay_ms <= 8000)
 );
 
 -- Create a table for Projects
@@ -168,3 +172,21 @@ create policy "CVs are publicly accessible."
 create policy "Authenticated users can upload CVs."
   on storage.objects for insert
   with check ( bucket_id = 'cvs' and auth.role() = 'authenticated' );
+
+-- ---------------------------------------------------------------------------
+-- Migration: loader_delay_ms (minimal-layout boot screen duration)
+-- Safe to run on an existing database; both statements are idempotent.
+-- ---------------------------------------------------------------------------
+alter table profiles
+  add column if not exists loader_delay_ms integer default 2800;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint where conname = 'loader_delay_range'
+  ) then
+    alter table profiles
+      add constraint loader_delay_range
+      check (loader_delay_ms >= 0 and loader_delay_ms <= 8000);
+  end if;
+end $$;

--- a/SETUP_DB.sql
+++ b/SETUP_DB.sql
@@ -22,7 +22,7 @@ create table profiles (
   cta_link text,
   theme text default 'dark',
   layout text default 'classic', -- Public profile layout: 'classic' | 'minimal'
-  loader_delay_ms integer default 2800, -- Minimal-layout boot screen duration; 0 disables it
+  loader_delay_ms integer default 0, -- Minimal-layout boot screen duration in ms; 0 = off, opt in from the dashboard
   beams_enabled boolean default true,
   is_donor boolean default false,
   cv_url text,
@@ -178,7 +178,14 @@ create policy "Authenticated users can upload CVs."
 -- Safe to run on an existing database; both statements are idempotent.
 -- ---------------------------------------------------------------------------
 alter table profiles
-  add column if not exists loader_delay_ms integer default 2800;
+  add column if not exists loader_delay_ms integer default 0;
+
+-- Corrects the default on databases where an earlier revision of this migration
+-- created the column with 2800. Does not touch existing rows — see the note in
+-- the PR for the one-time backfill, which must not live here or it would keep
+-- resetting anyone who deliberately picks 2.8s.
+alter table profiles
+  alter column loader_delay_ms set default 0;
 
 do $$
 begin

--- a/components/dashboard/LayoutSettings.tsx
+++ b/components/dashboard/LayoutSettings.tsx
@@ -53,7 +53,8 @@ const LOADER_OPTIONS = [
 const LayoutSettings: React.FC = () => {
     const { user, supabase } = useAuth();
     const [selected, setSelected] = useState('classic');
-    const [loaderDelay, setLoaderDelay] = useState(2800);
+    // Off unless the profile says otherwise — the boot screen is opt-in.
+    const [loaderDelay, setLoaderDelay] = useState(0);
     const [saving, setSaving] = useState(false);
 
     useEffect(() => {

--- a/components/dashboard/LayoutSettings.tsx
+++ b/components/dashboard/LayoutSettings.tsx
@@ -39,20 +39,38 @@ const MinimalPreview = () => (
     </div>
 );
 
+// Boot screen durations, in ms. Discrete steps rather than a free slider so a
+// profile can't end up behind an absurd wait. Must stay within the
+// loader_delay_range constraint in SETUP_DB.sql (0–8000).
+const LOADER_OPTIONS = [
+    { ms: 0, label: 'Off' },
+    { ms: 2000, label: '2s' },
+    { ms: 2800, label: '2.8s' },
+    { ms: 4000, label: '4s' },
+    { ms: 6000, label: '6s' },
+];
+
 const LayoutSettings: React.FC = () => {
     const { user, supabase } = useAuth();
     const [selected, setSelected] = useState('classic');
+    const [loaderDelay, setLoaderDelay] = useState(2800);
     const [saving, setSaving] = useState(false);
 
     useEffect(() => {
         const fetchLayout = async () => {
             if (!user) return;
+            // select('*') rather than naming loader_delay_ms: before the
+            // migration runs, naming a missing column errors the whole query
+            // and would take the layout picker down with it.
             const { data, error } = await supabase
                 .from('profiles')
-                .select('layout')
+                .select('*')
                 .eq('id', user.id)
                 .single();
-            if (data && !error && data.layout) setSelected(data.layout);
+            if (data && !error) {
+                if (data.layout) setSelected(data.layout);
+                if (typeof data.loader_delay_ms === 'number') setLoaderDelay(data.loader_delay_ms);
+            }
         };
         fetchLayout();
     }, [user, supabase]);
@@ -72,6 +90,26 @@ const LayoutSettings: React.FC = () => {
             console.error('Failed to save layout', err);
             toast.error('Failed to save layout');
             setSelected(previous);
+        } finally {
+            setTimeout(() => setSaving(false), 800);
+        }
+    };
+
+    const handleLoaderDelay = async (ms: number) => {
+        if (!user || ms === loaderDelay) return;
+        const previous = loaderDelay;
+        setLoaderDelay(ms);
+        setSaving(true);
+        try {
+            const { error } = await supabase
+                .from('profiles')
+                .update({ loader_delay_ms: ms, updated_at: new Date().toISOString() })
+                .eq('id', user.id);
+            if (error) throw error;
+        } catch (err) {
+            console.error('Failed to save loading screen delay', err);
+            toast.error('Failed to save loading screen delay');
+            setLoaderDelay(previous);
         } finally {
             setTimeout(() => setSaving(false), 800);
         }
@@ -128,6 +166,53 @@ const LayoutSettings: React.FC = () => {
                     </button>
                 ))}
             </div>
+
+            {/* Only the minimal layout has a boot screen, so this is scoped to it. */}
+            {selected === 'minimal' && (
+                <motion.div
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.35 }}
+                    className="mt-8 glass-card rounded-[2rem] border-white/5 p-6 md:p-8"
+                >
+                    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                        <div className="min-w-0">
+                            <p className="font-bold text-white tracking-tight">Loading screen</p>
+                            <p className="text-white/30 text-xs mt-0.5">
+                                How long visitors see the boot screen before your profile.
+                            </p>
+                        </div>
+
+                        <div className="flex items-center gap-1.5 glass p-1.5 rounded-2xl border-white/5 self-start sm:self-auto shrink-0">
+                            {LOADER_OPTIONS.map((opt) => (
+                                <button
+                                    key={opt.ms}
+                                    onClick={() => handleLoaderDelay(opt.ms)}
+                                    className={`relative px-3 sm:px-4 py-2 cursor-pointer rounded-xl text-[10px] font-black uppercase tracking-widest transition-colors ${loaderDelay === opt.ms
+                                        ? 'text-black'
+                                        : 'text-white/30 hover:text-white/60'
+                                        }`}
+                                >
+                                    <span className="relative z-10">{opt.label}</span>
+                                    {loaderDelay === opt.ms && (
+                                        <motion.div
+                                            layoutId="activeLoaderDelay"
+                                            className="absolute inset-0 bg-white rounded-xl shadow-xl"
+                                            transition={{ type: 'spring', bounce: 0.2, duration: 0.5 }}
+                                        />
+                                    )}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    <p className="text-white/20 text-[10px] mt-4 leading-relaxed">
+                        {loaderDelay === 0
+                            ? 'Visitors go straight to your profile.'
+                            : 'Shown once per visit. Visitors can skip it, and it is skipped entirely for anyone who prefers reduced motion.'}
+                    </p>
+                </motion.div>
+            )}
         </section>
     );
 };

--- a/components/profile/MinimalLoader.tsx
+++ b/components/profile/MinimalLoader.tsx
@@ -24,9 +24,11 @@ type Props = {
     durationMs?: number;
 };
 
-export const LOADER_DEFAULT_MS = 2800;
-export const LOADER_MIN_MS = 1200;
-export const LOADER_MAX_MS = 8000;
+// Not the product default — the boot screen is off unless an owner opts in.
+// This is only the duration used if a caller renders without `durationMs`.
+const FALLBACK_MS = 2800;
+const MIN_MS = 1200;
+const MAX_MS = 8000;
 const FADE_MS = 520;
 const GLYPHS = ["<", ">", "{", "}", "[", "]", "/", "0", "1", ";", "*", "$"];
 const BAR_SLOTS = 16;
@@ -114,10 +116,7 @@ const MinimalLoader: React.FC<Props> = ({
     const [animate, setAnimate] = useState(false);
     const dismissed = useRef(false);
 
-    const total = Math.min(
-        LOADER_MAX_MS,
-        Math.max(LOADER_MIN_MS, durationMs ?? LOADER_DEFAULT_MS)
-    );
+    const total = Math.min(MAX_MS, Math.max(MIN_MS, durationMs ?? FALLBACK_MS));
 
     /**
      * Every delay is a fraction of the total, so a shorter duration compresses

--- a/components/profile/MinimalLoader.tsx
+++ b/components/profile/MinimalLoader.tsx
@@ -63,25 +63,37 @@ function useRamp(active: boolean, duration: number, delay = 0) {
     return t;
 }
 
-const StatCell: React.FC<{ value: number | null; label: string; t: number }> = ({ value, label, t }) => (
-    <div className="border px-4 py-3" style={{ borderColor: "var(--theme-border)", background: "var(--theme-card-bg)" }}>
-        <div
-            className="font-serif-display text-2xl md:text-3xl tabular-nums"
-            style={{ color: "var(--theme-text)" }}
-        >
-            {value === null ? (
-                <span style={{ color: "var(--theme-accent)" }}>∞</span>
-            ) : (
-                Math.round(value * t)
-            )}
-        </div>
-        <p
-            className="mt-1 font-mono text-[9px] uppercase tracking-[0.2em]"
+/**
+ * An index row rather than a dashboard tile: hairline rule, mono label left,
+ * zero-padded serif numeral right — echoing how the minimal profile styles its
+ * own project list.
+ */
+const StatRow: React.FC<{ value: number; label: string; t: number; delay: number }> = ({
+    value,
+    label,
+    t,
+    delay,
+}) => (
+    <motion.div
+        className="flex items-baseline justify-between gap-6 py-3 border-b"
+        style={{ borderColor: "var(--theme-border)" }}
+        initial={{ opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45, delay }}
+    >
+        <span
+            className="font-mono text-[10px] uppercase tracking-[0.22em]"
             style={{ color: "var(--theme-text-secondary)" }}
         >
             {label}
-        </p>
-    </div>
+        </span>
+        <span
+            className="font-serif-display text-2xl md:text-3xl leading-none tabular-nums"
+            style={{ color: "var(--theme-text)" }}
+        >
+            {String(Math.round(value * t)).padStart(2, "0")}
+        </span>
+    </motion.div>
 );
 
 const MinimalLoader: React.FC<Props> = ({
@@ -117,6 +129,18 @@ const MinimalLoader: React.FC<Props> = ({
         );
         return out;
     }, [projectCount, techCount, isAvailable]);
+
+    // Empty counts are dropped rather than shown as "00" — a boot screen
+    // announcing zero projects is worse than not mentioning them.
+    const stats = useMemo(
+        () =>
+            [
+                { label: "Projects", value: projectCount },
+                { label: "Stack", value: techCount },
+                { label: "Links", value: linkCount },
+            ].filter((s) => s.value > 0),
+        [projectCount, techCount, linkCount]
+    );
 
     const dismiss = useCallback(() => {
         if (dismissed.current) return;
@@ -357,18 +381,23 @@ const MinimalLoader: React.FC<Props> = ({
                             </div>
                         </div>
 
-                        {/* Stats */}
-                        <motion.div
-                            className="mt-10 grid grid-cols-2 gap-4 md:gap-6"
-                            initial={{ opacity: 0, y: 12 }}
-                            animate={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.5, delay: 1.0 }}
-                        >
-                            <StatCell value={projectCount} label="Projects" t={ramp} />
-                            <StatCell value={techCount} label="Stack" t={ramp} />
-                            <StatCell value={linkCount} label="Links" t={ramp} />
-                            <StatCell value={null} label="Building" t={ramp} />
-                        </motion.div>
+                        {/* Index */}
+                        {stats.length > 0 && (
+                            <div
+                                className="mt-10 border-t"
+                                style={{ borderColor: "var(--theme-border)" }}
+                            >
+                                {stats.map((s, i) => (
+                                    <StatRow
+                                        key={s.label}
+                                        value={s.value}
+                                        label={s.label}
+                                        t={ramp}
+                                        delay={1.0 + i * 0.12}
+                                    />
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </motion.div>
             )}

--- a/components/profile/MinimalLoader.tsx
+++ b/components/profile/MinimalLoader.tsx
@@ -1,0 +1,354 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+/**
+ * Terminal-style boot screen for the minimal profile layout.
+ *
+ * Everything is themed off the --theme-* vars rather than hardcoded colours, so
+ * it inherits whichever palette the profile is using. Copy is derived from the
+ * visitor-facing profile data — no invented numbers.
+ */
+
+type Props = {
+    name: string;
+    profession?: string | null;
+    isAvailable?: boolean | null;
+    projectCount: number;
+    techCount: number;
+    linkCount: number;
+    /** Opaque background class for the overlay, so it matches the active theme
+     *  and fully hides the profile underneath. */
+    bgClass: string;
+};
+
+const TOTAL_MS = 2800;
+const FADE_MS = 520;
+const GLYPHS = ["<", ">", "{", "}", "[", "]", "/", "0", "1", ";", "*", "$"];
+const BAR_SLOTS = 16;
+
+/** Deterministic PRNG: keeps the glyph field stable across re-renders, and safe
+ *  if it is ever server-rendered (Math.random would trip a hydration mismatch). */
+function mulberry32(seed: number) {
+    return () => {
+        seed = (seed + 0x6d2b79f5) | 0;
+        let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/** Shared 0→1 ramp. One rAF loop drives the bar and every counter, so the
+ *  glyph field never re-renders. */
+function useRamp(active: boolean, duration: number, delay = 0) {
+    const [t, setT] = useState(0);
+    useEffect(() => {
+        if (!active) {
+            setT(1);
+            return;
+        }
+        let raf = 0;
+        let start: number | null = null;
+        const tick = (now: number) => {
+            if (start === null) start = now;
+            const p = Math.min(1, Math.max(0, (now - start - delay) / duration));
+            setT(p);
+            if (p < 1) raf = requestAnimationFrame(tick);
+        };
+        raf = requestAnimationFrame(tick);
+        return () => cancelAnimationFrame(raf);
+    }, [active, duration, delay]);
+    return t;
+}
+
+const StatCell: React.FC<{ value: number | null; label: string; t: number }> = ({ value, label, t }) => (
+    <div className="border px-4 py-3" style={{ borderColor: "var(--theme-border)", background: "var(--theme-card-bg)" }}>
+        <div
+            className="font-serif-display text-2xl md:text-3xl tabular-nums"
+            style={{ color: "var(--theme-text)" }}
+        >
+            {value === null ? (
+                <span style={{ color: "var(--theme-accent)" }}>∞</span>
+            ) : (
+                Math.round(value * t)
+            )}
+        </div>
+        <p
+            className="mt-1 font-mono text-[9px] uppercase tracking-[0.2em]"
+            style={{ color: "var(--theme-text-secondary)" }}
+        >
+            {label}
+        </p>
+    </div>
+);
+
+const MinimalLoader: React.FC<Props> = ({
+    name,
+    profession,
+    isAvailable,
+    projectCount,
+    techCount,
+    linkCount,
+    bgClass,
+}) => {
+    // Rendered on the server so the profile never flashes before the boot
+    // screen. The effect below decides whether it actually plays.
+    const [visible, setVisible] = useState(true);
+    const [animate, setAnimate] = useState(false);
+    const dismissed = useRef(false);
+
+    const firstName = (name || "").trim().split(/\s+/)[0] || "this developer";
+
+    const lines = useMemo(() => {
+        const out = ["Initializing profile..."];
+        out.push(
+            projectCount > 0
+                ? `Loading ${projectCount} project${projectCount === 1 ? "" : "s"}...`
+                : "Preparing workspace..."
+        );
+        if (techCount > 0) {
+            out.push(`Mounting ${techCount} technolog${techCount === 1 ? "y" : "ies"}...`);
+        }
+        out.push(
+            isAvailable ? "Status: available for work..." : "Status: heads down, building..."
+        );
+        return out;
+    }, [projectCount, techCount, isAvailable]);
+
+    const dismiss = useCallback(() => {
+        if (dismissed.current) return;
+        dismissed.current = true;
+        setVisible(false);
+    }, []);
+
+    useEffect(() => {
+        const reduceMotion =
+            typeof window !== "undefined" &&
+            window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+
+        // Once per tab: a repeat visitor should not sit through it again.
+        let alreadySeen = false;
+        try {
+            alreadySeen = sessionStorage.getItem("devbio:minimal-loader") === "1";
+            sessionStorage.setItem("devbio:minimal-loader", "1");
+        } catch {
+            /* private mode — just play it */
+        }
+
+        if (reduceMotion || alreadySeen) {
+            dismiss();
+            return;
+        }
+
+        setAnimate(true);
+        const timer = setTimeout(dismiss, TOTAL_MS);
+        return () => clearTimeout(timer);
+    }, [dismiss]);
+
+    // Hold the page still underneath while the overlay is up.
+    useEffect(() => {
+        if (!visible) return;
+        const prev = document.body.style.overflow;
+        document.body.style.overflow = "hidden";
+        return () => {
+            document.body.style.overflow = prev;
+        };
+    }, [visible]);
+
+    useEffect(() => {
+        if (!visible) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape" || e.key === "Enter" || e.key === " ") dismiss();
+        };
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [visible, dismiss]);
+
+    const ramp = useRamp(animate, TOTAL_MS - 500, 260);
+    const filled = Math.round(ramp * BAR_SLOTS);
+
+    const columns = useMemo(() => {
+        const rand = mulberry32(20260817);
+        return Array.from({ length: 18 }, () => ({
+            left: `${rand() * 100}%`,
+            duration: `${5 + rand() * 4}s`,
+            delay: `${rand() * 2.5}s`,
+            chars: Array.from({ length: 14 }, () => GLYPHS[Math.floor(rand() * GLYPHS.length)]),
+        }));
+    }, []);
+
+    return (
+        <AnimatePresence>
+            {visible && (
+                <motion.div
+                    id="minimal-loader"
+                    key="minimal-loader"
+                    initial={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={{ duration: FADE_MS / 1000, ease: "easeInOut" }}
+                    className={`fixed inset-0 z-[200] flex items-center justify-center overflow-hidden ${bgClass}`}
+                    role="status"
+                    aria-live="polite"
+                    aria-label="Loading profile"
+                >
+                    {/* Server-rendered so the profile never flashes first — which
+                        means without JS nothing would dismiss it. Hide it there. */}
+                    <noscript>
+                        <style
+                            dangerouslySetInnerHTML={{
+                                __html: "#minimal-loader{display:none !important}",
+                            }}
+                        />
+                    </noscript>
+
+                    {/* Depth wash */}
+                    <div
+                        className="absolute inset-0 pointer-events-none"
+                        style={{
+                            background:
+                                "radial-gradient(120% 90% at 50% 0%, var(--theme-card-bg) 0%, transparent 60%)",
+                        }}
+                    />
+
+                    {/* Falling glyph field */}
+                    {animate && (
+                        <div className="absolute inset-0 overflow-hidden pointer-events-none opacity-[0.05]">
+                            {columns.map((col, i) => (
+                                <div
+                                    key={i}
+                                    className="absolute top-0 font-mono text-[10px] leading-tight animate-matrix-fall"
+                                    style={{
+                                        left: col.left,
+                                        color: "var(--theme-accent)",
+                                        animationDuration: col.duration,
+                                        animationDelay: col.delay,
+                                    }}
+                                >
+                                    {col.chars.map((c, j) => (
+                                        <div key={j}>{c}</div>
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    )}
+
+                    <button
+                        type="button"
+                        onClick={dismiss}
+                        className="absolute top-6 right-6 z-10 font-mono text-[10px] uppercase tracking-[0.22em] transition-opacity hover:opacity-100 cursor-pointer"
+                        style={{ color: "var(--theme-text-secondary)" }}
+                    >
+                        Skip &rarr;
+                    </button>
+
+                    <div className="relative w-full max-w-xl mx-auto px-6 md:px-8">
+                        {/* Identity */}
+                        <motion.div
+                            className="mb-10"
+                            initial={{ opacity: 0, y: 8 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.5, delay: 0.15 }}
+                        >
+                            {profession && (
+                                <p
+                                    className="font-mono text-[10px] uppercase tracking-[0.24em]"
+                                    style={{ color: "var(--theme-accent)" }}
+                                >
+                                    {profession}
+                                </p>
+                            )}
+                            <p
+                                className="font-serif-display text-2xl mt-1"
+                                style={{ color: "var(--theme-text)" }}
+                            >
+                                {name}
+                            </p>
+                        </motion.div>
+
+                        {/* Terminal */}
+                        <div
+                            className="rounded border backdrop-blur-sm p-5 md:p-6 font-mono text-[12px] md:text-[13px] leading-relaxed"
+                            style={{
+                                borderColor: "var(--theme-border)",
+                                background: "var(--theme-card-bg)",
+                            }}
+                        >
+                            {lines.map((line, i) => (
+                                <motion.div
+                                    key={line}
+                                    className="mb-1"
+                                    style={{ color: "var(--theme-text-secondary)" }}
+                                    initial={{ opacity: 0 }}
+                                    animate={{ opacity: 1 }}
+                                    transition={{ duration: 0.25, delay: 0.5 + i * 0.32 }}
+                                >
+                                    <span className="mr-2" style={{ color: "var(--theme-accent)", opacity: 0.7 }}>
+                                        &gt;
+                                    </span>
+                                    {line}
+                                </motion.div>
+                            ))}
+                            <motion.div
+                                className="mt-3"
+                                style={{ color: "var(--theme-text)" }}
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                transition={{ duration: 0.3, delay: 2.05 }}
+                            >
+                                <span className="mr-2" style={{ color: "var(--theme-accent)" }}>
+                                    &gt;
+                                </span>
+                                Welcome to {firstName}&apos;s portfolio.
+                            </motion.div>
+                        </div>
+
+                        {/* Progress */}
+                        <div className="mt-8">
+                            <div
+                                className="flex items-center gap-3 font-mono text-[11px]"
+                                style={{ color: "var(--theme-text-secondary)" }}
+                            >
+                                <span
+                                    className="tracking-wider shrink-0"
+                                    style={{ color: "var(--theme-accent)" }}
+                                >
+                                    [{"#".repeat(filled)}
+                                    {".".repeat(BAR_SLOTS - filled)}]
+                                </span>
+                                <span className="truncate tabular-nums">
+                                    {Math.round(ramp * 100)}%
+                                </span>
+                            </div>
+                            <div
+                                className="mt-2 h-px overflow-hidden"
+                                style={{ background: "var(--theme-border)" }}
+                            >
+                                <motion.div
+                                    className="h-full"
+                                    style={{ background: "var(--theme-accent)" }}
+                                    initial={{ width: "0%" }}
+                                    animate={{ width: animate ? "100%" : "0%" }}
+                                    transition={{ duration: (TOTAL_MS - 500) / 1000, delay: 0.26, ease: "linear" }}
+                                />
+                            </div>
+                        </div>
+
+                        {/* Stats */}
+                        <motion.div
+                            className="mt-10 grid grid-cols-2 gap-4 md:gap-6"
+                            initial={{ opacity: 0, y: 12 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.5, delay: 1.0 }}
+                        >
+                            <StatCell value={projectCount} label="Projects" t={ramp} />
+                            <StatCell value={techCount} label="Stack" t={ramp} />
+                            <StatCell value={linkCount} label="Links" t={ramp} />
+                            <StatCell value={null} label="Building" t={ramp} />
+                        </motion.div>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+};
+
+export default MinimalLoader;

--- a/components/profile/MinimalLoader.tsx
+++ b/components/profile/MinimalLoader.tsx
@@ -19,12 +19,14 @@ type Props = {
     /** Opaque background class for the overlay, so it matches the active theme
      *  and fully hides the profile underneath. */
     bgClass: string;
-    /** ?loader=hold — play the sequence then stay up instead of dismissing, so
-     *  the finished state can be inspected. Skip still works. */
-    hold?: boolean;
+    /** How long the boot screen runs, in ms. Owner-configurable in the
+     *  dashboard; the caller is responsible for skipping render when it's 0. */
+    durationMs?: number;
 };
 
-const TOTAL_MS = 2800;
+export const LOADER_DEFAULT_MS = 2800;
+export const LOADER_MIN_MS = 1200;
+export const LOADER_MAX_MS = 8000;
 const FADE_MS = 520;
 const GLYPHS = ["<", ">", "{", "}", "[", "]", "/", "0", "1", ";", "*", "$"];
 const BAR_SLOTS = 16;
@@ -104,13 +106,38 @@ const MinimalLoader: React.FC<Props> = ({
     techCount,
     linkCount,
     bgClass,
-    hold = false,
+    durationMs,
 }) => {
     // Rendered on the server so the profile never flashes before the boot
     // screen. The effect below decides whether it actually plays.
     const [visible, setVisible] = useState(true);
     const [animate, setAnimate] = useState(false);
     const dismissed = useRef(false);
+
+    const total = Math.min(
+        LOADER_MAX_MS,
+        Math.max(LOADER_MIN_MS, durationMs ?? LOADER_DEFAULT_MS)
+    );
+
+    /**
+     * Every delay is a fraction of the total, so a shorter duration compresses
+     * the whole sequence instead of leaving the closing line to fire after the
+     * overlay has already gone. The fractions reproduce the original hand-tuned
+     * timings at the 2800ms default.
+     */
+    const at = useMemo(
+        () => ({
+            header: 0.05 * total,
+            linesStart: 0.18 * total,
+            lineStep: 0.11 * total,
+            finalLine: 0.73 * total,
+            statsStart: 0.36 * total,
+            statStep: 0.043 * total,
+            rampDelay: 0.09 * total,
+            rampDuration: 0.82 * total,
+        }),
+        [total]
+    );
 
     const firstName = (name || "").trim().split(/\s+/)[0] || "this developer";
 
@@ -149,13 +176,6 @@ const MinimalLoader: React.FC<Props> = ({
     }, []);
 
     useEffect(() => {
-        // Inspection mode: always play, never time out, and don't burn the
-        // once-per-tab flag so normal visits still get the full thing.
-        if (hold) {
-            setAnimate(true);
-            return;
-        }
-
         const reduceMotion =
             typeof window !== "undefined" &&
             window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
@@ -175,9 +195,9 @@ const MinimalLoader: React.FC<Props> = ({
         }
 
         setAnimate(true);
-        const timer = setTimeout(dismiss, TOTAL_MS);
+        const timer = setTimeout(dismiss, total);
         return () => clearTimeout(timer);
-    }, [dismiss, hold]);
+    }, [dismiss, total]);
 
     // Hold the page still underneath while the overlay is up.
     useEffect(() => {
@@ -198,7 +218,7 @@ const MinimalLoader: React.FC<Props> = ({
         return () => window.removeEventListener("keydown", onKey);
     }, [visible, dismiss]);
 
-    const ramp = useRamp(animate, TOTAL_MS - 500, 260);
+    const ramp = useRamp(animate, at.rampDuration, at.rampDelay);
     const filled = Math.round(ramp * BAR_SLOTS);
 
     const columns = useMemo(() => {
@@ -217,11 +237,11 @@ const MinimalLoader: React.FC<Props> = ({
                 <motion.div
                     id="minimal-loader"
                     key="minimal-loader"
-                    {...(hold ? { "data-hold": "true" } : {})}
                     initial={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: FADE_MS / 1000, ease: "easeInOut" }}
                     className={`fixed inset-0 z-[200] flex items-center justify-center overflow-hidden ${bgClass}`}
+                    style={{ "--loader-failsafe": `${total + 2000}ms` } as React.CSSProperties}
                     role="status"
                     aria-live="polite"
                     aria-label="Loading profile"
@@ -267,27 +287,14 @@ const MinimalLoader: React.FC<Props> = ({
                         </div>
                     )}
 
-                    <div className="absolute top-6 right-6 z-10 flex items-center gap-4">
-                        {hold && (
-                            <span
-                                className="font-mono text-[10px] uppercase tracking-[0.22em] border px-2 py-1"
-                                style={{
-                                    color: "var(--theme-accent)",
-                                    borderColor: "var(--theme-border)",
-                                }}
-                            >
-                                Hold
-                            </span>
-                        )}
-                        <button
-                            type="button"
-                            onClick={dismiss}
-                            className="font-mono text-[10px] uppercase tracking-[0.22em] transition-opacity hover:opacity-100 cursor-pointer"
-                            style={{ color: "var(--theme-text-secondary)" }}
-                        >
-                            Skip &rarr;
-                        </button>
-                    </div>
+                    <button
+                        type="button"
+                        onClick={dismiss}
+                        className="absolute top-6 right-6 z-10 font-mono text-[10px] uppercase tracking-[0.22em] transition-opacity hover:opacity-100 cursor-pointer"
+                        style={{ color: "var(--theme-text-secondary)" }}
+                    >
+                        Skip &rarr;
+                    </button>
 
                     <div className="relative w-full max-w-xl mx-auto px-6 md:px-8">
                         {/* Identity */}
@@ -295,7 +302,7 @@ const MinimalLoader: React.FC<Props> = ({
                             className="mb-10"
                             initial={{ opacity: 0, y: 8 }}
                             animate={{ opacity: 1, y: 0 }}
-                            transition={{ duration: 0.5, delay: 0.15 }}
+                            transition={{ duration: 0.5, delay: at.header / 1000 }}
                         >
                             {profession && (
                                 <p
@@ -328,7 +335,7 @@ const MinimalLoader: React.FC<Props> = ({
                                     style={{ color: "var(--theme-text-secondary)" }}
                                     initial={{ opacity: 0 }}
                                     animate={{ opacity: 1 }}
-                                    transition={{ duration: 0.25, delay: 0.5 + i * 0.32 }}
+                                    transition={{ duration: 0.25, delay: (at.linesStart + i * at.lineStep) / 1000 }}
                                 >
                                     <span className="mr-2" style={{ color: "var(--theme-accent)", opacity: 0.7 }}>
                                         &gt;
@@ -341,7 +348,7 @@ const MinimalLoader: React.FC<Props> = ({
                                 style={{ color: "var(--theme-text)" }}
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
-                                transition={{ duration: 0.3, delay: 2.05 }}
+                                transition={{ duration: 0.3, delay: at.finalLine / 1000 }}
                             >
                                 <span className="mr-2" style={{ color: "var(--theme-accent)" }}>
                                     &gt;
@@ -376,7 +383,7 @@ const MinimalLoader: React.FC<Props> = ({
                                     style={{ background: "var(--theme-accent)" }}
                                     initial={{ width: "0%" }}
                                     animate={{ width: animate ? "100%" : "0%" }}
-                                    transition={{ duration: (TOTAL_MS - 500) / 1000, delay: 0.26, ease: "linear" }}
+                                    transition={{ duration: at.rampDuration / 1000, delay: at.rampDelay / 1000, ease: "linear" }}
                                 />
                             </div>
                         </div>
@@ -393,7 +400,7 @@ const MinimalLoader: React.FC<Props> = ({
                                         value={s.value}
                                         label={s.label}
                                         t={ramp}
-                                        delay={1.0 + i * 0.12}
+                                        delay={(at.statsStart + i * at.statStep) / 1000}
                                     />
                                 ))}
                             </div>

--- a/components/profile/MinimalLoader.tsx
+++ b/components/profile/MinimalLoader.tsx
@@ -19,6 +19,9 @@ type Props = {
     /** Opaque background class for the overlay, so it matches the active theme
      *  and fully hides the profile underneath. */
     bgClass: string;
+    /** ?loader=hold — play the sequence then stay up instead of dismissing, so
+     *  the finished state can be inspected. Skip still works. */
+    hold?: boolean;
 };
 
 const TOTAL_MS = 2800;
@@ -89,6 +92,7 @@ const MinimalLoader: React.FC<Props> = ({
     techCount,
     linkCount,
     bgClass,
+    hold = false,
 }) => {
     // Rendered on the server so the profile never flashes before the boot
     // screen. The effect below decides whether it actually plays.
@@ -121,6 +125,13 @@ const MinimalLoader: React.FC<Props> = ({
     }, []);
 
     useEffect(() => {
+        // Inspection mode: always play, never time out, and don't burn the
+        // once-per-tab flag so normal visits still get the full thing.
+        if (hold) {
+            setAnimate(true);
+            return;
+        }
+
         const reduceMotion =
             typeof window !== "undefined" &&
             window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
@@ -142,7 +153,7 @@ const MinimalLoader: React.FC<Props> = ({
         setAnimate(true);
         const timer = setTimeout(dismiss, TOTAL_MS);
         return () => clearTimeout(timer);
-    }, [dismiss]);
+    }, [dismiss, hold]);
 
     // Hold the page still underneath while the overlay is up.
     useEffect(() => {
@@ -182,6 +193,7 @@ const MinimalLoader: React.FC<Props> = ({
                 <motion.div
                     id="minimal-loader"
                     key="minimal-loader"
+                    {...(hold ? { "data-hold": "true" } : {})}
                     initial={{ opacity: 1 }}
                     exit={{ opacity: 0 }}
                     transition={{ duration: FADE_MS / 1000, ease: "easeInOut" }}
@@ -231,14 +243,27 @@ const MinimalLoader: React.FC<Props> = ({
                         </div>
                     )}
 
-                    <button
-                        type="button"
-                        onClick={dismiss}
-                        className="absolute top-6 right-6 z-10 font-mono text-[10px] uppercase tracking-[0.22em] transition-opacity hover:opacity-100 cursor-pointer"
-                        style={{ color: "var(--theme-text-secondary)" }}
-                    >
-                        Skip &rarr;
-                    </button>
+                    <div className="absolute top-6 right-6 z-10 flex items-center gap-4">
+                        {hold && (
+                            <span
+                                className="font-mono text-[10px] uppercase tracking-[0.22em] border px-2 py-1"
+                                style={{
+                                    color: "var(--theme-accent)",
+                                    borderColor: "var(--theme-border)",
+                                }}
+                            >
+                                Hold
+                            </span>
+                        )}
+                        <button
+                            type="button"
+                            onClick={dismiss}
+                            className="font-mono text-[10px] uppercase tracking-[0.22em] transition-opacity hover:opacity-100 cursor-pointer"
+                            style={{ color: "var(--theme-text-secondary)" }}
+                        >
+                            Skip &rarr;
+                        </button>
+                    </div>
 
                     <div className="relative w-full max-w-xl mx-auto px-6 md:px-8">
                         {/* Identity */}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -62,4 +62,6 @@ export type UserProfile = {
     is_donor?: boolean;
     cv_url?: string;
     layout?: string;
+    /** Minimal-layout boot screen duration in ms. 0 disables it. */
+    loader_delay_ms?: number | null;
 };

--- a/pages/[profile].tsx
+++ b/pages/[profile].tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import { supabase } from "../lib/supabaseClient";
 import MinimalProfile from "../components/profile/MinimalProfile";
-import MinimalLoader, { LOADER_DEFAULT_MS } from "../components/profile/MinimalLoader";
+import MinimalLoader from "../components/profile/MinimalLoader";
 import ClassicProfile from "../components/profile/ClassicProfile";
 import PublicShareModal from "../components/PublicShareModal";
 import { THEME_CONFIG } from "../lib/constants";
@@ -77,9 +77,9 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
   }
 
   const isMinimal = user.layout === 'minimal';
-  // Owner-configured boot screen duration. 0 turns it off; null (older rows
-  // that predate the column) falls back to the default.
-  const loaderDelay = user.loader_delay_ms ?? LOADER_DEFAULT_MS;
+  // Boot screen is opt-in: off unless the owner picked a duration. Null (rows
+  // predating the column) is treated the same as 0.
+  const loaderDelay = user.loader_delay_ms ?? 0;
   const loaderEnabled = loaderDelay > 0;
   // Minimal defaults to the warm "sand" palette. The default-ish dark themes
   // (onyx / dark / unset) fall through to sand so minimal reads warm out of the

--- a/pages/[profile].tsx
+++ b/pages/[profile].tsx
@@ -17,6 +17,8 @@ import type { UserProfile, ProjectRecord } from "../lib/types";
 type Props = {
   user: UserProfile | null;
   projects: ProjectRecord[];
+  /** ?loader=hold — keep the minimal boot screen up for inspection. */
+  loaderHold: boolean;
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
@@ -24,8 +26,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     ? context.params?.profile[0]
     : context.params?.profile;
 
+  // Read here rather than from useRouter so SSR and hydration agree.
+  const loaderHold = context.query.loader === 'hold';
+
   if (!usernameParam) {
-    return { props: { user: null, projects: [] } };
+    return { props: { user: null, projects: [], loaderHold } };
   }
 
   //  Fetch Profile
@@ -37,7 +42,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (profileError || !profile) {
     console.error('Profile not found:', usernameParam);
-    return { props: { user: null, projects: [] } };
+    return { props: { user: null, projects: [], loaderHold } };
   }
 
   //  Fetch Projects
@@ -57,11 +62,12 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     props: {
       user: layoutOverride ? { ...profile, layout: layoutOverride } : profile,
       projects: projects || [],
+      loaderHold,
     },
   };
 };
 
-const ProfilePage: React.FC<Props> = ({ user, projects }) => {
+const ProfilePage: React.FC<Props> = ({ user, projects, loaderHold }) => {
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const { recordClick } = useProfileAnalytics(user?.id);
 
@@ -148,6 +154,7 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
             techCount={(user.tech_stack || []).length}
             linkCount={(user.social_links || []).filter((s) => s.href).length}
             bgClass={isImageBg ? 'bg-black' : bgConfig}
+            hold={loaderHold}
           />
           <MinimalProfile
             user={user}

--- a/pages/[profile].tsx
+++ b/pages/[profile].tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import { supabase } from "../lib/supabaseClient";
 import MinimalProfile from "../components/profile/MinimalProfile";
+import MinimalLoader from "../components/profile/MinimalLoader";
 import ClassicProfile from "../components/profile/ClassicProfile";
 import PublicShareModal from "../components/PublicShareModal";
 import { THEME_CONFIG } from "../lib/constants";
@@ -138,12 +139,23 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
       )}
 
       {isMinimal ? (
-        <MinimalProfile
-          user={user}
-          projects={projects}
-          recordClick={recordClick}
-          onShare={() => setShareModalOpen(true)}
-        />
+        <>
+          <MinimalLoader
+            name={user.full_name}
+            profession={user.profession}
+            isAvailable={user.is_available}
+            projectCount={projects.length}
+            techCount={(user.tech_stack || []).length}
+            linkCount={(user.social_links || []).filter((s) => s.href).length}
+            bgClass={isImageBg ? 'bg-black' : bgConfig}
+          />
+          <MinimalProfile
+            user={user}
+            projects={projects}
+            recordClick={recordClick}
+            onShare={() => setShareModalOpen(true)}
+          />
+        </>
       ) : (
         <ClassicProfile
           user={user}

--- a/pages/[profile].tsx
+++ b/pages/[profile].tsx
@@ -7,7 +7,7 @@ import { useState } from "react";
 import { AnimatePresence } from "framer-motion";
 import { supabase } from "../lib/supabaseClient";
 import MinimalProfile from "../components/profile/MinimalProfile";
-import MinimalLoader from "../components/profile/MinimalLoader";
+import MinimalLoader, { LOADER_DEFAULT_MS } from "../components/profile/MinimalLoader";
 import ClassicProfile from "../components/profile/ClassicProfile";
 import PublicShareModal from "../components/PublicShareModal";
 import { THEME_CONFIG } from "../lib/constants";
@@ -17,8 +17,6 @@ import type { UserProfile, ProjectRecord } from "../lib/types";
 type Props = {
   user: UserProfile | null;
   projects: ProjectRecord[];
-  /** ?loader=hold — keep the minimal boot screen up for inspection. */
-  loaderHold: boolean;
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
@@ -26,11 +24,8 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     ? context.params?.profile[0]
     : context.params?.profile;
 
-  // Read here rather than from useRouter so SSR and hydration agree.
-  const loaderHold = context.query.loader === 'hold';
-
   if (!usernameParam) {
-    return { props: { user: null, projects: [], loaderHold } };
+    return { props: { user: null, projects: [] } };
   }
 
   //  Fetch Profile
@@ -42,7 +37,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   if (profileError || !profile) {
     console.error('Profile not found:', usernameParam);
-    return { props: { user: null, projects: [], loaderHold } };
+    return { props: { user: null, projects: [] } };
   }
 
   //  Fetch Projects
@@ -62,12 +57,11 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     props: {
       user: layoutOverride ? { ...profile, layout: layoutOverride } : profile,
       projects: projects || [],
-      loaderHold,
     },
   };
 };
 
-const ProfilePage: React.FC<Props> = ({ user, projects, loaderHold }) => {
+const ProfilePage: React.FC<Props> = ({ user, projects }) => {
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const { recordClick } = useProfileAnalytics(user?.id);
 
@@ -83,6 +77,10 @@ const ProfilePage: React.FC<Props> = ({ user, projects, loaderHold }) => {
   }
 
   const isMinimal = user.layout === 'minimal';
+  // Owner-configured boot screen duration. 0 turns it off; null (older rows
+  // that predate the column) falls back to the default.
+  const loaderDelay = user.loader_delay_ms ?? LOADER_DEFAULT_MS;
+  const loaderEnabled = loaderDelay > 0;
   // Minimal defaults to the warm "sand" palette. The default-ish dark themes
   // (onyx / dark / unset) fall through to sand so minimal reads warm out of the
   // box; a distinctive chosen theme (forest, midnight, matrix, ...) still wins.
@@ -146,16 +144,18 @@ const ProfilePage: React.FC<Props> = ({ user, projects, loaderHold }) => {
 
       {isMinimal ? (
         <>
-          <MinimalLoader
-            name={user.full_name}
-            profession={user.profession}
-            isAvailable={user.is_available}
-            projectCount={projects.length}
-            techCount={(user.tech_stack || []).length}
-            linkCount={(user.social_links || []).filter((s) => s.href).length}
-            bgClass={isImageBg ? 'bg-black' : bgConfig}
-            hold={loaderHold}
-          />
+          {loaderEnabled && (
+            <MinimalLoader
+              name={user.full_name}
+              profession={user.profession}
+              isAvailable={user.is_available}
+              projectCount={projects.length}
+              techCount={(user.tech_stack || []).length}
+              linkCount={(user.social_links || []).filter((s) => s.href).length}
+              bgClass={isImageBg ? 'bg-black' : bgConfig}
+              durationMs={loaderDelay}
+            />
+          )}
           <MinimalProfile
             user={user}
             projects={projects}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -31,6 +31,33 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+/* Failsafe for the minimal-layout boot screen. The overlay is server-rendered
+   so the profile never flashes first, which means only JS removes it — a
+   hydration failure would hide the portfolio for good. This clears it without
+   JS after well past the scripted exit. Only `visibility` is keyframed (with
+   step-end), so framer-motion's inline opacity exit is left alone; animating
+   opacity here would override it and break the fade. */
+@keyframes loader-failsafe {
+  to {
+    visibility: hidden;
+  }
+}
+
+#minimal-loader {
+  animation: loader-failsafe 6.5s step-end forwards;
+}
+
+/* Minimal-layout boot screen: columns of glyphs drifting down the viewport.
+   Duration and delay are set per column inline so they desynchronise. */
+@keyframes matrix-fall {
+  0% {
+    transform: translateY(-100%);
+  }
+  100% {
+    transform: translateY(100vh);
+  }
+}
+
 /* Global Scrollbar */
 ::-webkit-scrollbar {
   width: 10px;
@@ -130,6 +157,18 @@ body {
   .font-profile h1 {
     font-weight: 400;
     letter-spacing: -0.025em;
+  }
+
+  .animate-matrix-fall {
+    animation-name: matrix-fall;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-matrix-fall {
+      animation: none;
+    }
   }
 
   .font-profile :is(h2, h3, h4, h5) {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -43,7 +43,8 @@ body {
   }
 }
 
-#minimal-loader {
+/* :not([data-hold]) so ?loader=hold isn't yanked away at 6.5s by the failsafe. */
+#minimal-loader:not([data-hold]) {
   animation: loader-failsafe 6.5s step-end forwards;
 }
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -43,9 +43,11 @@ body {
   }
 }
 
-/* :not([data-hold]) so ?loader=hold isn't yanked away at 6.5s by the failsafe. */
-#minimal-loader:not([data-hold]) {
-  animation: loader-failsafe 6.5s step-end forwards;
+/* The delay comes from an inline var (the owner's configured duration plus a
+   margin) so a longer boot screen isn't cut short by its own safety net. The
+   inline style is server-rendered, so it still applies with no JS. */
+#minimal-loader {
+  animation: loader-failsafe var(--loader-failsafe, 6.5s) step-end forwards;
 }
 
 /* Minimal-layout boot screen: columns of glyphs drifting down the viewport.


### PR DESCRIPTION
## Summary

Adds a terminal-style boot screen to the minimal profile layout, off by
default, with an owner-configurable duration in the dashboard.

Inspired by jidebuilds.com, but adapted on two counts: themed off the
`--theme-*` vars instead of hardcoded colours so it inherits whatever palette
the profile uses, and the copy is built from real profile data — project/tech/
link counts, availability — since this renders on every user's profile. No
invented numbers, and lines drop out when data is absent.

## Opt-in by default

A 2.8s gate in front of a portfolio someone just clicked is a real cost, so the
default is **Off**. Nobody inherits a boot screen; you turn it on if you want it.

## Dashboard control

**Themes → Layout**, shown only when Minimal is selected. `Off / 2s / 2.8s / 4s / 6s`
— discrete steps rather than a slider so the value stays inside the DB
constraint.

