### PR TITLE
Feat/font picker

### DIFF
--- a/SETUP_DB.sql
+++ b/SETUP_DB.sql
@@ -23,6 +23,7 @@ create table profiles (
   theme text default 'dark',
   layout text default 'classic', -- Public profile layout: 'classic' | 'minimal'
   loader_delay_ms integer default 0, -- Minimal-layout boot screen duration in ms; 0 = off, opt in from the dashboard
+  profile_font text default 'editorial', -- Public profile typography preset; see lib/profileFonts.ts
   beams_enabled boolean default true,
   is_donor boolean default false,
   cv_url text,
@@ -197,3 +198,10 @@ begin
       check (loader_delay_ms >= 0 and loader_delay_ms <= 8000);
   end if;
 end $$;
+
+-- ---------------------------------------------------------------------------
+-- Migration: profile_font (public profile typography preset)
+-- Safe to run on an existing database.
+-- ---------------------------------------------------------------------------
+alter table profiles
+  add column if not exists profile_font text default 'editorial';

--- a/components/dashboard/FontSettings.tsx
+++ b/components/dashboard/FontSettings.tsx
@@ -1,0 +1,122 @@
+import React, { useState, useEffect } from 'react';
+import { motion } from 'framer-motion';
+import { FiCheck, FiLoader } from 'react-icons/fi';
+import { useAuth } from '../../lib/AuthContext';
+import { toast } from 'react-toastify';
+import { PROFILE_FONTS, DEFAULT_PROFILE_FONT } from '../../lib/profileFonts';
+
+/**
+ * Typography picker for the public profile. Each tile renders its own specimen
+ * in the face it selects, which is the only preview that actually tells you
+ * anything — a font name set in a different font is useless.
+ */
+const FontSettings: React.FC = () => {
+    const { user, supabase } = useAuth();
+    const [selected, setSelected] = useState(DEFAULT_PROFILE_FONT);
+    const [saving, setSaving] = useState(false);
+
+    useEffect(() => {
+        const fetchFont = async () => {
+            if (!user) return;
+            // select('*') rather than naming the column: naming one that does not
+            // exist fails the whole query, which would break this panel on a
+            // database where the migration has not been applied yet.
+            const { data, error } = await supabase
+                .from('profiles')
+                .select('*')
+                .eq('id', user.id)
+                .single();
+            if (data && !error && data.profile_font) setSelected(data.profile_font);
+        };
+        fetchFont();
+    }, [user, supabase]);
+
+    const handleSelect = async (id: string) => {
+        if (!user || id === selected) return;
+        const previous = selected;
+        setSelected(id);
+        setSaving(true);
+        try {
+            const { error } = await supabase
+                .from('profiles')
+                .update({ profile_font: id, updated_at: new Date().toISOString() })
+                .eq('id', user.id);
+            if (error) throw error;
+        } catch (err) {
+            console.error('Failed to save font', err);
+            toast.error('Failed to save font');
+            setSelected(previous);
+        } finally {
+            setTimeout(() => setSaving(false), 800);
+        }
+    };
+
+    return (
+        <section className="mb-12">
+            <div className="mb-6 flex items-end justify-between gap-4">
+                <div className="text-center md:text-left">
+                    <h3 className="text-2xl font-black text-white tracking-tighter">Typography</h3>
+                    <p className="text-white/40 text-sm font-medium uppercase tracking-widest mt-1">
+                        The type on your public profile
+                    </p>
+                </div>
+                {saving && (
+                    <div className="flex items-center gap-2 text-yellow-500 font-bold text-xs uppercase tracking-widest animate-pulse shrink-0">
+                        <FiLoader className="animate-spin" />
+                        <span>Syncing...</span>
+                    </div>
+                )}
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {PROFILE_FONTS.map((font) => {
+                    const active = selected === font.id;
+                    return (
+                        <button
+                            key={font.id}
+                            onClick={() => handleSelect(font.id)}
+                            className={`group relative text-left cursor-pointer rounded-[1.5rem] border-2 p-5 bg-[#0c0b09] transition-all duration-300 ${active
+                                ? 'border-blue-500'
+                                : 'border-white/5 hover:border-white/15'
+                                }`}
+                        >
+                            {active && (
+                                <motion.div
+                                    initial={{ opacity: 0, scale: 0.5 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    className="absolute top-4 right-4 w-7 h-7 bg-blue-500 rounded-lg flex items-center justify-center text-white"
+                                >
+                                    <FiCheck size={14} />
+                                </motion.div>
+                            )}
+
+                            {/* Specimen, set in the face this option applies */}
+                            <div
+                                className="text-white text-3xl leading-none pr-10"
+                                style={{ fontFamily: `var(${font.previewVar})` }}
+                            >
+                                Ag
+                            </div>
+                            <div
+                                className="text-white/50 text-sm mt-2 pr-10 truncate"
+                                style={{ fontFamily: `var(${font.previewVar})` }}
+                            >
+                                The quick brown fox
+                            </div>
+
+                            <p
+                                className={`mt-4 font-bold tracking-tight transition-colors ${active ? 'text-white' : 'text-white/40 group-hover:text-white/70'
+                                    }`}
+                            >
+                                {font.name}
+                            </p>
+                            <p className="text-white/30 text-xs mt-0.5">{font.description}</p>
+                        </button>
+                    );
+                })}
+            </div>
+        </section>
+    );
+};
+
+export default FontSettings;

--- a/components/profile/MinimalLoader.tsx
+++ b/components/profile/MinimalLoader.tsx
@@ -92,7 +92,7 @@ const StatRow: React.FC<{ value: number; label: string; t: number; delay: number
             {label}
         </span>
         <span
-            className="font-serif-display text-2xl md:text-3xl leading-none tabular-nums"
+            className="font-profile-display text-2xl md:text-3xl leading-none tabular-nums"
             style={{ color: "var(--theme-text)" }}
         >
             {String(Math.round(value * t)).padStart(2, "0")}
@@ -312,7 +312,7 @@ const MinimalLoader: React.FC<Props> = ({
                                 </p>
                             )}
                             <p
-                                className="font-serif-display text-2xl mt-1"
+                                className="font-profile-display text-2xl mt-1"
                                 style={{ color: "var(--theme-text)" }}
                             >
                                 {name}

--- a/components/profile/MinimalProfile.tsx
+++ b/components/profile/MinimalProfile.tsx
@@ -29,7 +29,7 @@ const MinimalProfile: React.FC<Props> = ({ user, projects, recordClick, onShare 
     const hasProjects = projects && projects.length > 0;
 
     return (
-        <main className="font-dm min-h-screen px-6 py-16 md:py-24 selection:bg-[var(--theme-text)] selection:text-[var(--theme-card-bg)]">
+        <main className="font-profile-body min-h-screen px-6 py-16 md:py-24 selection:bg-[var(--theme-text)] selection:text-[var(--theme-card-bg)]">
             <motion.div
                 initial={{ opacity: 0, y: 12 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -51,7 +51,7 @@ const MinimalProfile: React.FC<Props> = ({ user, projects, recordClick, onShare 
                         )}
                     </div>
 
-                    <h1 className="font-serif-display text-[2.6rem] md:text-[3.25rem] leading-[1.05] tracking-[-0.02em] text-[var(--theme-text)] mt-6">
+                    <h1 className="font-profile-display text-[2.6rem] md:text-[3.25rem] leading-[1.05] tracking-[-0.02em] text-[var(--theme-text)] mt-6">
                         {user.full_name}
                     </h1>
 
@@ -104,7 +104,7 @@ const MinimalProfile: React.FC<Props> = ({ user, projects, recordClick, onShare 
                 {/* Tech stack */}
                 {hasTech && (
                     <section className="mb-12">
-                        <h2 className="font-serif-display text-[1.75rem] leading-none text-[var(--theme-text)] pb-4 mb-5 border-b border-[var(--theme-border)]">
+                        <h2 className="font-profile-display text-[1.75rem] leading-none text-[var(--theme-text)] pb-4 mb-5 border-b border-[var(--theme-border)]">
                             Stack
                         </h2>
                         <p className="text-[14px] leading-relaxed text-[var(--theme-text-secondary)]">
@@ -121,7 +121,7 @@ const MinimalProfile: React.FC<Props> = ({ user, projects, recordClick, onShare 
                 {/* Projects */}
                 {hasProjects && (
                     <section className="mt-6 mb-16">
-                        <h2 className="font-serif-display text-[1.75rem] leading-none text-[var(--theme-text)] pb-5 mb-2 border-b border-[var(--theme-border)]">
+                        <h2 className="font-profile-display text-[1.75rem] leading-none text-[var(--theme-text)] pb-5 mb-2 border-b border-[var(--theme-border)]">
                             Projects
                         </h2>
                         <ul>
@@ -141,7 +141,7 @@ const MinimalProfile: React.FC<Props> = ({ user, projects, recordClick, onShare 
                                                 : {})}
                                             className="group block"
                                         >
-                                            <h3 className="font-serif-display text-[17px] leading-snug text-[var(--theme-text)] transition-opacity group-hover:opacity-70">
+                                            <h3 className="font-profile-display text-[17px] leading-snug text-[var(--theme-text)] transition-opacity group-hover:opacity-70">
                                                 {project.title}
                                             </h3>
                                             {domain && (

--- a/lib/fonts.ts
+++ b/lib/fonts.ts
@@ -1,10 +1,25 @@
-import { Outfit, Newsreader, DM_Sans, JetBrains_Mono } from 'next/font/google';
+import {
+    Outfit,
+    Newsreader,
+    DM_Sans,
+    JetBrains_Mono,
+    Space_Grotesk,
+    Sora,
+    Instrument_Serif,
+    Fraunces,
+    Plus_Jakarta_Sans,
+} from 'next/font/google';
 
 // Fonts are loaded here rather than via @import in globals.css: Tailwind v4
 // strips remote `@import url(...)` rules out of the bundle, so the Google Fonts
 // import never shipped and every family silently fell back to system sans.
 // next/font self-hosts the files and exposes each as a CSS variable, which
 // globals.css consumes.
+//
+// The four app faces below preload. The owner-selectable profile faces further
+// down set `preload: false` on purpose: they are declared for every page but a
+// browser only fetches a webfont once something actually renders in it, so a
+// visitor to a profile using Outfit never downloads Fraunces.
 
 const outfit = Outfit({
     subsets: ['latin'],
@@ -34,12 +49,61 @@ const jetbrainsMono = JetBrains_Mono({
     display: 'swap',
 });
 
+// ---------------------------------------------------------------------------
+// Owner-selectable profile faces. See lib/profileFonts.ts for the presets.
+// ---------------------------------------------------------------------------
+
+const spaceGrotesk = Space_Grotesk({
+    subsets: ['latin'],
+    variable: '--font-space-grotesk',
+    display: 'swap',
+    preload: false,
+});
+
+const sora = Sora({
+    subsets: ['latin'],
+    variable: '--font-sora',
+    display: 'swap',
+    preload: false,
+});
+
+// Single weight (400) by design — it is a display face. Heading weights are
+// pinned in globals.css and font-synthesis is off, so 500 resolves to 400
+// without faux-bolding.
+const instrumentSerif = Instrument_Serif({
+    subsets: ['latin'],
+    weight: ['400'],
+    style: ['normal', 'italic'],
+    variable: '--font-instrument-serif',
+    display: 'swap',
+    preload: false,
+});
+
+const fraunces = Fraunces({
+    subsets: ['latin'],
+    variable: '--font-fraunces',
+    display: 'swap',
+    preload: false,
+});
+
+const plusJakarta = Plus_Jakarta_Sans({
+    subsets: ['latin'],
+    variable: '--font-plus-jakarta',
+    display: 'swap',
+    preload: false,
+});
+
 /** Font variable classes, for the element wrapping the React tree. */
 export const fontVariables = [
     outfit.variable,
     newsreader.variable,
     dmSans.variable,
     jetbrainsMono.variable,
+    spaceGrotesk.variable,
+    sora.variable,
+    instrumentSerif.variable,
+    fraunces.variable,
+    plusJakarta.variable,
 ].join(' ');
 
 /**
@@ -53,4 +117,9 @@ export const rootFontStyles = `:root{`
     + `--font-newsreader:${newsreader.style.fontFamily};`
     + `--font-dm-sans:${dmSans.style.fontFamily};`
     + `--font-jetbrains-mono:${jetbrainsMono.style.fontFamily};`
+    + `--font-space-grotesk:${spaceGrotesk.style.fontFamily};`
+    + `--font-sora:${sora.style.fontFamily};`
+    + `--font-instrument-serif:${instrumentSerif.style.fontFamily};`
+    + `--font-fraunces:${fraunces.style.fontFamily};`
+    + `--font-plus-jakarta:${plusJakarta.style.fontFamily};`
     + `}`;

--- a/lib/profileFonts.ts
+++ b/lib/profileFonts.ts
@@ -1,0 +1,98 @@
+// Owner-selectable typography for public profiles.
+//
+// Each preset is a pairing rather than a single family: a display face for
+// headings and a body face for running text. Several presets use one family for
+// both, but the serif display faces are paired with a neutral sans, because
+// Instrument Serif or Fraunces set at 14px for a whole bio reads badly.
+//
+// `display` / `body` are complete font-family stacks, substituted straight into
+// CSS custom properties by pages/[profile].tsx. The families themselves are
+// loaded in lib/fonts.ts.
+
+export type ProfileFont = {
+    id: string;
+    /** Shown in the dashboard picker. */
+    name: string;
+    /** One-line character note. */
+    description: string;
+    /** Heading stack. */
+    display: string;
+    /** Body stack. */
+    body: string;
+    /** Which var to preview the name in, so each option renders in its own face. */
+    previewVar: string;
+};
+
+export const PROFILE_FONTS: ProfileFont[] = [
+    {
+        id: 'editorial',
+        name: 'Editorial',
+        description: 'Newsreader headings, DM Sans body',
+        display: 'var(--font-newsreader), Georgia, ui-serif, serif',
+        body: 'var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-newsreader',
+    },
+    {
+        id: 'instrument',
+        name: 'Instrument',
+        description: 'High-contrast display serif, sans body',
+        display: 'var(--font-instrument-serif), Georgia, ui-serif, serif',
+        body: 'var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-instrument-serif',
+    },
+    {
+        id: 'fraunces',
+        name: 'Fraunces',
+        description: 'Soft, characterful serif with a sans body',
+        display: 'var(--font-fraunces), Georgia, ui-serif, serif',
+        body: 'var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-fraunces',
+    },
+    {
+        id: 'grotesk',
+        name: 'Space Grotesk',
+        description: 'Geometric and a little technical',
+        display: 'var(--font-space-grotesk), ui-sans-serif, system-ui, sans-serif',
+        body: 'var(--font-space-grotesk), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-space-grotesk',
+    },
+    {
+        id: 'sora',
+        name: 'Sora',
+        description: 'Clean, wide, slightly futuristic',
+        display: 'var(--font-sora), ui-sans-serif, system-ui, sans-serif',
+        body: 'var(--font-sora), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-sora',
+    },
+    {
+        id: 'jakarta',
+        name: 'Jakarta',
+        description: 'Neutral modern sans, quietly gets out of the way',
+        display: 'var(--font-plus-jakarta), ui-sans-serif, system-ui, sans-serif',
+        body: 'var(--font-plus-jakarta), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-plus-jakarta',
+    },
+    {
+        id: 'outfit',
+        name: 'Outfit',
+        description: 'Rounded geometric sans, the DevBio house face',
+        display: 'var(--font-outfit), ui-sans-serif, system-ui, sans-serif',
+        body: 'var(--font-outfit), ui-sans-serif, system-ui, sans-serif',
+        previewVar: '--font-outfit',
+    },
+    {
+        id: 'mono',
+        name: 'Mono',
+        description: 'JetBrains Mono throughout, unmistakably a developer',
+        display: 'var(--font-jetbrains-mono), ui-monospace, monospace',
+        body: 'var(--font-jetbrains-mono), ui-monospace, monospace',
+        previewVar: '--font-jetbrains-mono',
+    },
+];
+
+/** Preset used when a profile has not chosen one — the pre-existing look. */
+export const DEFAULT_PROFILE_FONT = 'editorial';
+
+export const getProfileFont = (id?: string | null): ProfileFont =>
+    PROFILE_FONTS.find((f) => f.id === id) ??
+    PROFILE_FONTS.find((f) => f.id === DEFAULT_PROFILE_FONT)!;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -64,4 +64,6 @@ export type UserProfile = {
     layout?: string;
     /** Minimal-layout boot screen duration in ms. 0 disables it. */
     loader_delay_ms?: number | null;
+    /** Public profile typography preset id. See lib/profileFonts.ts. */
+    profile_font?: string | null;
 };

--- a/pages/[profile].tsx
+++ b/pages/[profile].tsx
@@ -11,6 +11,7 @@ import MinimalLoader from "../components/profile/MinimalLoader";
 import ClassicProfile from "../components/profile/ClassicProfile";
 import PublicShareModal from "../components/PublicShareModal";
 import { THEME_CONFIG } from "../lib/constants";
+import { getProfileFont, PROFILE_FONTS } from "../lib/profileFonts";
 import { useProfileAnalytics } from "../hooks/useProfileAnalytics";
 import type { UserProfile, ProjectRecord } from "../lib/types";
 
@@ -53,9 +54,20 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   const layoutOverride =
     layoutQuery === 'minimal' || layoutQuery === 'classic' ? layoutQuery : null;
 
+  // Same for typography: /username?font=mono
+  const fontQuery = context.query.font;
+  const fontOverride =
+    typeof fontQuery === 'string' && PROFILE_FONTS.some((f) => f.id === fontQuery)
+      ? fontQuery
+      : null;
+
   return {
     props: {
-      user: layoutOverride ? { ...profile, layout: layoutOverride } : profile,
+      user: {
+        ...profile,
+        ...(layoutOverride ? { layout: layoutOverride } : {}),
+        ...(fontOverride ? { profile_font: fontOverride } : {}),
+      },
       projects: projects || [],
     },
   };
@@ -96,7 +108,11 @@ const ProfilePage: React.FC<Props> = ({ user, projects }) => {
   const bgConfig = themeConfig.bg;
   const isImageBg = bgConfig.startsWith('http');
 
+  const profileFont = getProfileFont(user.profile_font);
+
   const themeStyles = {
+    '--profile-display': profileFont.display,
+    '--profile-body': profileFont.body,
     '--theme-card-bg': themeConfig.card,
     '--theme-border': themeConfig.border,
     '--theme-accent': themeConfig.accent,

--- a/pages/dashboard/themes.tsx
+++ b/pages/dashboard/themes.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import DashboardLayout from '../../components/dashboard/DashboardLayout';
 import ThemeSettings from '../../components/dashboard/ThemeSettings';
 import LayoutSettings from '../../components/dashboard/LayoutSettings';
+import FontSettings from '../../components/dashboard/FontSettings';
 
 const ThemesPage: React.FC = () => {
     return (
@@ -15,6 +16,7 @@ const ThemesPage: React.FC = () => {
                     <p className="text-white/40 text-base font-light italic">Customize your profile&apos;s appearance and design.</p>
                 </div>
                 <LayoutSettings />
+                <FontSettings />
                 <ThemeSettings />
             </div>
 
@@ -32,6 +34,7 @@ const ThemesPage: React.FC = () => {
                     {/* Scrollable Content */}
                     <div className="flex-1 overflow-y-auto px-10 pb-10 custom-scrollbar">
                         <LayoutSettings />
+                        <FontSettings />
                         <ThemeSettings />
                     </div>
                 </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -125,20 +125,24 @@ body {
     scrollbar-width: none;
   }
 
-  /* Minimal layout typography */
-  .font-serif-display {
-    font-family: var(--font-newsreader), Georgia, ui-serif, serif;
+  /* Profile typography helpers, for the places that need to name a face
+     explicitly rather than inherit. Both follow the owner's chosen preset, so a
+     profile set to Mono does not keep serif headings. Named "display"/"body"
+     rather than after a specific family, since a preset may be sans or mono. */
+  .font-profile-display {
+    font-family: var(--profile-display, var(--font-newsreader)), Georgia, ui-serif, serif;
   }
 
-  .font-dm {
-    font-family: var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif;
+  .font-profile-body {
+    font-family: var(--profile-body, var(--font-dm-sans)), ui-sans-serif, system-ui, sans-serif;
   }
 
-  /* Public profile typography — the akinkunmi.dev pairing: Newsreader for
-     display headings, DM Sans for everything else. Deliberately not the app's
-     default Outfit, and the same two faces the minimal layout already uses. */
+  /* Public profile typography. The owner picks a preset in the dashboard;
+     pages/[profile].tsx sets --profile-display / --profile-body inline from it.
+     The fallbacks are the previous hardcoded pairing (Newsreader + DM Sans), so
+     a profile with no choice saved looks exactly as it did before. */
   .font-profile {
-    font-family: var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif;
+    font-family: var(--profile-body, var(--font-dm-sans)), ui-sans-serif, system-ui, sans-serif;
     font-synthesis-weight: none;
     -webkit-font-synthesis: none;
     font-synthesis: none;
@@ -154,7 +158,7 @@ body {
      `:is(h1, ...)` rule resolves to (0,2,0) and would beat a later
      `.font-profile h1` at (0,1,1). No overlap means no cascade to lose. */
   .font-profile :is(h1, h2, h3, h4, h5) {
-    font-family: var(--font-newsreader), Georgia, ui-serif, serif;
+    font-family: var(--profile-display, var(--font-newsreader)), Georgia, ui-serif, serif;
   }
 
   .font-profile h1 {


### PR DESCRIPTION
## Summary

Lets users pick the typography for their public profile from eight presets,
in **Themes → Typography**.

Each preset is a *pairing*, not a single family. Instrument Serif or Fraunces set
at 14px for a whole bio reads badly, so the display serifs carry a DM Sans body
while the sans and mono presets use one family throughout.

| Preset | Display / Body |
|---|---|
| Editorial *(default)* | Newsreader / DM Sans |
| Instrument | Instrument Serif / DM Sans |
| Fraunces | Fraunces / DM Sans |
| Space Grotesk | itself |
| Sora | itself |
| Jakarta | Plus Jakarta Sans |
| Outfit | itself |
| Mono | JetBrains Mono |

Applies to both layouts, since classic and minimal share `.font-profile`.
